### PR TITLE
fix quit chan bug; fix timed looper goroutine leak

### DIFF
--- a/director_test.go
+++ b/director_test.go
@@ -52,10 +52,13 @@ func Test_TimedLooper(t *testing.T) {
 
 		Convey("The loop exits when told to quit", func() {
 			looper.Count = FOREVER
-			go looper.Loop(func() error { time.Sleep(5 * time.Nanosecond); return nil })
+			count := 0
+
+			go looper.Loop(func() error { count++; time.Sleep(2 * time.Nanosecond); return nil })
 			looper.Quit()
 
 			So(looper.Wait(), ShouldBeNil)
+			So(count, ShouldBeLessThan, 2)
 		})
 	})
 }
@@ -114,10 +117,13 @@ func Test_FreeLooper(t *testing.T) {
 
 		Convey("The loop exits when told to quit", func() {
 			looper.Count = FOREVER
-			go looper.Loop(func() error { time.Sleep(1 * time.Nanosecond); return nil })
+			count := 0
+
+			go looper.Loop(func() error { count++; time.Sleep(2 * time.Nanosecond); return nil })
 			looper.Quit()
 
 			So(looper.Wait(), ShouldBeNil)
+			So(count, ShouldBeLessThan, 2)
 		})
 	})
 }


### PR DESCRIPTION
- quitChan does not appear to have worked for some time (not 100% sure why - possibly something to do with scoping and closures when .Loop() is ran inside a goroutine?)
  - moving quitChan creation into NewTimedLooper() and NewFreeLooper() appears to have fixed the issue (and tests)
- really ugly, bad and dumb bug with the runIteration() - there was nothing in place to tell .Loop() to finish running/break when max iterations reached (or something passed on quitChan). Oops. Sorry @relistan and @actaeon.
