### PR TITLE
Remove assign-only boolean

### DIFF
--- a/director.go
+++ b/director.go
@@ -81,11 +81,8 @@ func (l *TimedLooper) Done(err error) {
 func (l *TimedLooper) Loop(fn func() error) {
 	i := 0
 
-	var stop bool
-
 	stopFunc := func(err error) {
 		l.Done(err)
-		stop = true
 	}
 
 	runIteration := func() {


### PR DESCRIPTION
The `stop` bool is never read, only written to – and in go 1.11, apparently the compiler got smart enough to notice and declare it an error.